### PR TITLE
Update v-0.1.11.ebuild

### DIFF
--- a/dev-lang/v/v-0.1.11.ebuild
+++ b/dev-lang/v/v-0.1.11.ebuild
@@ -13,7 +13,7 @@ else
 	SRC_URI="
 		https://github.com/vlang/v/releases/download/v${PV}/v.zip -> ${P}.zip
 		https://raw.githubusercontent.com/vlang/vc/master/v.c -> v.c"
-	KEYWORDS="~amd64"
+	KEYWORDS="~amd64 ~arm64"
 fi
 
 LICENSE="MIT"


### PR DESCRIPTION
built by hand a few weeks ago..

pi64 ~/v # neofetch
         -/oyddmdhs+:.                root@pi64
 OS: Gentoo Base System release 2.7 aarch64
    Host: Raspberry Pi 4 Model B Rev 1.2
  Kernel: 5.4.45-v8-3b41649ff96d-p4-bis+
 Uptime: 5 days, 8 hours, 47 mins
Packages: 2160 (emerge), 113 (pkg)
Shell: bash 5.0.17
Resolution: 1024x768
 Terminal: /dev/pts/10
  CPU: BCM2835 (4) @ 2.000GHz
    Memory: 2997MiB / 3744MiB

pi64 ~/v # ./v
For usage information, quit V REPL and run `v help`
^C
pi64 ~/v # ./v helo
v helo: unknown command
Run "v help" for usage.
pi64 ~/v # ./v help